### PR TITLE
README.md: add link to "NYU Libraries Research Guides"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 [![CircleCI](https://circleci.com/gh/NYULibraries/libguides-styles.svg?style=svg)](https://circleci.com/gh/NYULibraries/libguides-styles)
 
-Manage the CSS and JS for NYU Libraries' instance of SpringShare's LibGuides (LG) product.
+Manage the CSS and JS for NYU Libraries' instance of SpringShare's LibGuides (LG) product:
+[NYU Libraries Research Guides](https://guides.nyu.edu/)
 
 ## CSS
 


### PR DESCRIPTION
The impetus for this branch was to test that deployment works for new access key, but it's useful to have the link in the README.md anyway.