### PR TITLE
CircleCI config: remove `aws-s3` orb and switch to `machine` executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
-docker-defaults: &docker-defaults
-  docker:
-    - image: quay.io/nyulibraries/circleci_docker:18.06.1-dc-1.23.2-0
+machine-defaults: &machine-defaults
+  machine:
+    image: ubuntu-2204:current
   working_directory: ~/app
 
 aws_env: &aws_env
@@ -35,10 +35,9 @@ orbs:
   aws-s3: circleci/aws-s3@1.0.11
 jobs:
   deploy-dev:
-    <<: *docker-defaults
+    <<: *machine-defaults
     steps:
       - checkout
-      - setup_remote_docker
       - run:
           name: Export Dev environment
           command: |
@@ -49,12 +48,11 @@ jobs:
       - *s3_deploy
       - store_artifacts:
           path: dist
-    
+
   deploy-prod:
-    <<: *docker-defaults
+    <<: *machine-defaults
     steps:
       - checkout
-      - setup_remote_docker
       - run:
           name: Export Dev environment
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,13 +10,17 @@ aws_env: &aws_env
       echo 'export AWS_ACCESS_KEY_ID=${WEB_CDN_AWS_ACCESS_KEY_ID}' >> $BASH_ENV
       echo 'export AWS_SECRET_ACCESS_KEY=${WEB_CDN_AWS_SECRET_ACCESS_KEY}' >> $BASH_ENV
 
-s3_deploy: &s3_deploy
-  aws-s3/sync:
-    from: dist
-    to: '${S3_URI}/libguides'
-    arguments: |
-      --delete
-    overwrite: true
+# Note that `aws s3 sync ... --exact-timestamps` only works for downloads from S3,
+# not uploads: https://github.com/aws/aws-cli/issues/4460.  The only safe way
+# to update is to upload absolutely everything using `cp` and then deleting
+# removed files using `sync --delete`.  There are many other open GitHub issues
+# related to this behavior.  Here's another: https://github.com/aws/aws-cli/issues/3273.
+aws-sync-s3: &aws-sync-s3
+  run:
+    name: Deploy to S3
+    command: |
+      aws s3 cp --recursive dist ${S3_URI}/libguides && \
+      aws s3 sync --delete dist ${S3_URI}/libguides
 
 webpack_build: &webpack_build
   run:
@@ -45,7 +49,7 @@ jobs:
       - *aws_env
       - *webpack_build
       - *webpack_copy
-      - *s3_deploy
+      - *aws-sync-s3
       - store_artifacts:
           path: dist
 
@@ -60,7 +64,7 @@ jobs:
       - *aws_env
       - *webpack_build
       - *webpack_copy
-      - *s3_deploy
+      - *aws-sync-s3
       - store_artifacts:
           path: dist
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ webpack_build: &webpack_build
   run:
     name: Webpack
     command: |
-      NODE_ENV=${NODE_ENV} docker-compose run build
+      NODE_ENV=${NODE_ENV} docker compose run build
 
 webpack_copy: &webpack_copy
   run:

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ Even though these two pages need to be managed via different templates because o
 Using an nginx proxy we can develop our styles and JS locally in realtime. To bring up the local proxy do the following:
 
 ```
-docker-compose build
-docker-compose up dev
+docker compose build
+docker compose up dev
 # Visit localhost:8080
 ```
 


### PR DESCRIPTION
* Need to remove old `aws-s3` orb to prevent brownout: [2024 Image Deprecations and Brownouts \- Android, Linux VM , Remote Docker, Linux VM](https://support.circleci.com/hc/en-us/articles/23614965074459-2024-Image-Deprecations-and-Brownouts-Android-Linux-VM-Remote-Docker-Linux-VM).
* Need to remove docker executor with old Docker 18 image to prevent this error: [Pushing and pulling with image manifest v2 schema 1](https://docs.docker.com/engine/deprecated/#pushing-and-pulling-with-image-manifest-v2-schema-1).  Switching to `machine` executor to simplify and reduce maintenance.  We've agreed to use `ubuntu-2204:current` image for all projects we switch over.