### PR TITLE
Update styling for BESS instances in LibGuides

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "node-sass": "^4.13.1",
     "sass-loader": "^8.0.0",
     "webpack": "^4.41.5",
-    "webpack-cli": "^3.3.10"
+    "webpack-cli": "^3.3.10",
+    "webpack-fix-style-only-entries": "^0.6.1"
   },
   "engines": {
     "node": "13"

--- a/scss/bess.scss
+++ b/scss/bess.scss
@@ -1,0 +1,315 @@
+.bobcat_embed {
+    border-radius: 3px;
+    font-family: "NYUPerstare", Helvetica, Arial, sans-serif;
+    font-size: 14px;
+}
+
+.bobcat_embed a {
+    color: #0170B2;
+}
+
+.bobcat_embed_ {
+    display: flex;
+    flex-grow: 1;
+    padding-top: 14px;
+}
+
+.bobcat_embed ul {
+    list-style: none;
+    list-style-position: inside;
+    margin: 0;
+    padding: 0
+}
+
+.bobcat_embed_links ul {
+    list-style-type: disc;
+    margin: 0;
+    padding: 0;
+}
+
+.bobcat_embed_searchbox {
+    background: #fff;
+    border-radius: 0 3px 3px 3px;
+    border: 1px solid #e7ebef;
+    box-shadow: 1px 1px 0 rgba(0, 0, 0, 0.1);
+    padding: 20px 30px;
+    zoom: 1;
+}
+
+.bobcat_embed_searchbox:before, .bobcat_embed_searchbox:after {
+    content: "";
+    display: table
+}
+
+.bobcat_embed_searchbox:after {
+    clear: both
+}
+
+.bobcat_embed_searchbox .bobcat_embed_search_field {
+    align-items: center;
+    display: flex;
+    gap: 10px;
+    width: 100%
+}
+
+@media only screen and (max-width: 870px) {
+    .bobcat_embed_searchbox .bobcat_embed_search_field {
+        flex-direction: column
+    }
+}
+
+/*.bobcat_embed_searchbox .bobcat_embed_searchbox_textfield {*/
+/*    margin-right: 414px;*/
+/*}*/
+
+/*@media only screen and (max-width: 1050px) {*/
+/*    .bobcat_embed_searchbox .bobcat_embed_searchbox_textfield {*/
+/*        margin-right:206px*/
+/*    }*/
+/*}*/
+
+/*@media only screen and (max-width: 870px) {*/
+/*    .bobcat_embed_searchbox .bobcat_embed_searchbox_textfield {*/
+/*        margin-right:500px*/
+/*    }*/
+/*}*/
+
+/*@media only screen and (max-width: 600px) {*/
+/*    .bobcat_embed_searchbox .bobcat_embed_searchbox_textfield {*/
+/*        margin-right:300px*/
+/*    }*/
+/*}*/
+
+.bobcat_embed_searchbox .bobat_embed_searchbox_submit_container {
+    flex-shrink: 0;
+    margin-bottom: 16px;
+}
+
+.bobat_embed_searchbox_submit_container input[type="submit"] {
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    appearance: none;
+    background: #57068c;
+    border-radius: 3px;
+    border: 0 none;
+    box-shadow: none;
+    color: #fff;
+    display: inline-block;
+    font-weight: 400;
+    height: 44px;
+    margin-bottom: 15px;
+    padding: 5px 15px;
+    text-align: center;
+    text-decoration: none;
+}
+
+@media only screen and (max-width: 1050px) {
+    .bobcat_embed_searchbox .bobat_embed_searchbox_submit_container {
+        margin-right: 10px
+    }
+}
+
+@media only screen and (max-width: 870px) {
+    .bobcat_embed_searchbox .bobat_embed_searchbox_submit_container {
+        margin-top: 0
+    }
+}
+
+.bobcat_embed_searchbox .bobcat_embed_select_value {
+    border-radius: 3px;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.1);
+    color: #1C2127;
+    flex-grow: 0;
+    font-size: 14px;
+    height: 44px;
+    margin-bottom: 30px;
+    margin-top: 29px;
+    width: auto
+}
+
+@media only screen and (max-width: 870px) {
+    .bobcat_embed_searchbox .bobcat_embed_select_value {
+        margin-top: 0
+    }
+}
+
+@media only screen and (max-width: 600px) {
+    .bobcat_embed_searchbox .bobcat_embed_select_value {
+        padding: 10px 10px 10px 10px;
+        width: 70%
+    }
+}
+
+@media only screen and (max-width: 570px) {
+    .bobcat_embed_searchbox .bobcat_embed_select_value {
+        font-size: 16px;
+        width: 67%
+    }
+}
+
+@media only screen and (max-width: 540px) {
+    .bobcat_embed_searchbox .bobcat_embed_select_value {
+        font-size: 16px;
+        width: 72%
+    }
+}
+
+@media only screen and (max-width: 500px) {
+    .bobcat_embed_searchbox .bobcat_embed_select_value {
+        font-size: 14px;
+        width: 65%
+    }
+}
+
+@media only screen and (max-width: 450px) {
+    .bobcat_embed_searchbox .bobcat_embed_select_value {
+        width: 85%
+    }
+}
+
+@media only screen and (max-width: 414px) {
+    .bobcat_embed_searchbox .bobcat_embed_select_value {
+        font-size: 14px;
+        width: 80%
+    }
+}
+
+@media only screen and (max-width: 380px) {
+    .bobcat_embed_searchbox .bobcat_embed_select_value {
+        font-size: 12px;
+        width: 75%
+    }
+}
+
+.bobcat_embed_searchbox select, .bobcat_embed_searchbox .filter--checkbox {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background: url("https://library.nyu.edu/assets/images/select-arrow-violet.svg") center right #fafbfc no-repeat;
+    background-size: 25px 25px;
+    padding-left: 15px;
+    padding-right: 30px;
+}
+
+@media only screen and (max-width: 585px) {
+    .bobcat_embed_searchbox {
+        padding: 20px
+    }
+}
+
+.bobcat_embed_searchbox label {
+    flex-wrap: nowrap;
+    font-size: 14px;
+    height: 44px;
+    margin-bottom: 0;
+    margin-right: 10px;
+    padding-top: 8px;
+    text-align: center;
+}
+
+.bobcat_embed_searchbox input[type="text"], .bobcat_embed_searchbox input[type="email"], .bobcat_embed_searchbox input[type="url"], .bobcat_embed_searchbox input[type="password"] {
+    background: #fafbfc;
+    border-radius: 3px;
+    border: 1px solid #e7ebef;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.1);
+    display: inline-block;
+    flex-grow: 1;
+    height: 44px;
+    margin-bottom: 15px;
+    padding: 10px;
+}
+
+.bobcat_embed_searchbox li:first-child {
+    font-size: 14px
+}
+
+.bobcat_embed_searchbox li:last-child {
+    margin-bottom: 0
+}
+
+@media only screen and (min-width: 586px) {
+    .bobat_embed_searchbox_submit_container {
+        float: right;
+        margin-top: 30px
+    }
+}
+
+@media only screen and (max-width: 585px) {
+    .bobcat_embed input[type="submit"] {
+        display: block;
+        width: 100%
+    }
+}
+
+.bobcat_embed_limit_to select, .bobcat_embed_limit_to .filter--checkbox {
+    margin: 5px 0
+}
+
+.bobcat_embed_journal_search_type {
+    display: block
+}
+
+.bobcat_embed_tabs {
+    zoom: 1;
+}
+
+.bobcat_embed_tabs:before, .bobcat_embed_tabs:after {
+    content: "";
+    display: table
+}
+
+.bobcat_embed_tabs:after {
+    clear: both
+}
+
+.bobcat_embed_tabs li {
+    float: left;
+    font-size: 16px;
+    margin-right: 5px;
+    vertical-align: bottom;
+}
+
+.bobcat_embed_tabs li[id^='bobcat_beta'] a {
+    background-color: #F8E71C
+}
+
+.bobcat_embed_tabs a, .bobcat_embed_tabs .block .s-la-widget a, .block .s-la-widget .bobcat_embed_tabs a {
+    background: #fff;
+    border-radius: 3px 3px 0 0;
+    border: 1px solid #e7ebef;
+    color: #4a4f55;
+    display: inline-block;
+    padding: 15px;
+    text-decoration: none;
+}
+
+@media only screen and (max-width: 865px) {
+    .bobcat_embed_tabs a, .bobcat_embed_tabs .block .s-la-widget a, .block .s-la-widget .bobcat_embed_tabs a {
+        padding: 10px
+    }
+}
+
+@media only screen and (max-width: 770px) {
+    .bobcat_embed_tabs a, .bobcat_embed_tabs .block .s-la-widget a, .block .s-la-widget .bobcat_embed_tabs a {
+        border-radius: 3px;
+        margin-bottom: 5px
+    }
+}
+
+@media only screen and (max-width: 450px) {
+    .bobcat_embed_tabs a, .bobcat_embed_tabs .block .s-la-widget a, .block .s-la-widget .bobcat_embed_tabs a {
+        padding: 5px;
+        font-size: 12px
+    }
+}
+
+.bobcat_embed_tabs a:hover {
+    text-decoration: underline
+}
+
+.bobcat_embed_tabs_selected a, .bobcat_embed_tabs_selected .block .s-la-widget a, .block .s-la-widget .bobcat_embed_tabs_selected a, .bobcat_embed_tabs_selected a:hover {
+    background: #22272d;
+    border-bottom-color: #22272d;
+    color: #fff;
+    pointer-events: none
+}

--- a/scss/bess.scss
+++ b/scss/bess.scss
@@ -58,28 +58,6 @@
     }
 }
 
-/*.bobcat_embed_searchbox .bobcat_embed_searchbox_textfield {*/
-/*    margin-right: 414px;*/
-/*}*/
-
-/*@media only screen and (max-width: 1050px) {*/
-/*    .bobcat_embed_searchbox .bobcat_embed_searchbox_textfield {*/
-/*        margin-right:206px*/
-/*    }*/
-/*}*/
-
-/*@media only screen and (max-width: 870px) {*/
-/*    .bobcat_embed_searchbox .bobcat_embed_searchbox_textfield {*/
-/*        margin-right:500px*/
-/*    }*/
-/*}*/
-
-/*@media only screen and (max-width: 600px) {*/
-/*    .bobcat_embed_searchbox .bobcat_embed_searchbox_textfield {*/
-/*        margin-right:300px*/
-/*    }*/
-/*}*/
-
 .bobcat_embed_searchbox .bobat_embed_searchbox_submit_container {
     flex-shrink: 0;
     margin-bottom: 16px;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const FixStyleOnlyEntriesPlugin = require("webpack-fix-style-only-entries");
 
 const isProduction = process.env.NODE_ENV === 'production';
 const isStaging = process.env.NODE_ENV === 'staging';
@@ -10,10 +11,16 @@ module.exports = {
       './js/index.js',
       './scss/index.scss',
     ],
+    // An "empty" bess.min.js file is created for this styles-only entry.
+    // We remove it using:
+    // https://github.com/fqborges/webpack-fix-style-only-entries
+    bess: [
+      './scss/bess.scss',
+    ],
     dataservices: [
       './js/dataservices.js',
       './scss/dataservices.scss',
-    ]
+    ],
   },
   output: {
     path: path.resolve(__dirname, 'dist'),
@@ -49,4 +56,8 @@ module.exports = {
       },
     ],
   },
+  plugins : [
+    // See comment for `entry.bess` above.
+    new FixStyleOnlyEntriesPlugin(),
+  ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4560,6 +4560,11 @@ webpack-cli@^3.3.10:
     v8-compile-cache "2.0.3"
     yargs "13.2.4"
 
+webpack-fix-style-only-entries@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/webpack-fix-style-only-entries/-/webpack-fix-style-only-entries-0.6.1.tgz#8e517085cc3426ccd1cb37ff2897b993563a424a"
+  integrity sha512-wyIhoxS3DD3Fr9JA8hQPA+ZmaWnqPxx12Nv166wcsI/0fbReqyEtiIk2llOFYIg57WVS3XX5cZJxw2ji70R0sA==
+
 webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"


### PR DESCRIPTION
monday.com: [Update Styling for BESS instances in LibGuides](https://nyu-lib.monday.com/boards/765008773/pulses/7347827763)

* Add _scss/bess.scss_
* Add webpack plugin for removing "empty" emitted JS files for entries that are CSS only (like BESS)