### PR TITLE
 Implement Bootstrap 5 LibGuides styles

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -51,6 +51,10 @@ if (isBootstrap5Preview) {
 	document.documentElement.classList.add("s-lg-bs5-preview");
 }
 
+// Springshare's BS5 preview pages can still render tab controls with the BS3
+// `data-toggle="tab"` attribute. Bootstrap 5 listens for `data-bs-toggle`,
+// so add the BS5 attribute only on preview pages to keep those tabs working
+// without changing current BS3 guide behavior.
 function syncBootstrap5TabAttributes() {
 	document.querySelectorAll('[data-toggle="tab"]').forEach(function(tab) {
 		if (!tab.hasAttribute("data-bs-toggle")) {
@@ -139,4 +143,3 @@ function loadNYUPerstareFonts() {
 }
 
 loadNYUPerstareFonts();
-

--- a/js/index.js
+++ b/js/index.js
@@ -48,7 +48,7 @@ function getQueryParameterValue(name) {
 const isBootstrap5Preview = getQueryParameterValue("bs5") === "1";
 
 if (isBootstrap5Preview) {
-	document.documentElement.classList.add("s-lg-bs5-preview");
+	document.documentElement.classList.add("nyu-libguides-bs5-preview");
 }
 
 // Springshare-rendered subject detail pages, for example
@@ -68,7 +68,7 @@ function syncBootstrap5TabAttributes() {
 // This is inherited jQuery, it needs to be reviewed and possibly eliminated
 $(document).ready(function() {
 	if (isBootstrap5Preview) {
-		document.body.classList.add("s-lg-bs5-preview");
+		document.body.classList.add("nyu-libguides-bs5-preview");
 		syncBootstrap5TabAttributes();
 	}
 

--- a/js/index.js
+++ b/js/index.js
@@ -51,10 +51,12 @@ if (isBootstrap5Preview) {
 	document.documentElement.classList.add("s-lg-bs5-preview");
 }
 
-// Springshare's BS5 preview pages can still render tab controls with the BS3
-// `data-toggle="tab"` attribute. Bootstrap 5 listens for `data-bs-toggle`,
-// so add the BS5 attribute only on preview pages to keep those tabs working
-// without changing current BS3 guide behavior.
+// Springshare-rendered subject detail pages, for example
+// `/subject_africana?bs5=1` and `/subject_business?bs5=1`, still output the
+// Guides / Preferred Databases tabs with the BS3 `data-toggle="tab"` attribute.
+// Bootstrap 5 listens for `data-bs-toggle`, so add the BS5 attribute only
+// on preview pages to bridge that markup mismatch without changing current
+// BS3 guide behavior.
 function syncBootstrap5TabAttributes() {
 	document.querySelectorAll('[data-toggle="tab"]').forEach(function(tab) {
 		if (!tab.hasAttribute("data-bs-toggle")) {

--- a/js/index.js
+++ b/js/index.js
@@ -6,8 +6,66 @@ var info_style_change = function() {
 	$('.s-lg-label-more-info').hide();
 }
 
+// The BS5 preview gate must be exact because non-bs5 pages share this bundle.
+// A regex would be smaller, but it would make query parsing rules implicit in
+// the pattern. URLSearchParams would express the intent best, but this legacy
+// build target adds extra core-js polyfill code for it. This helper is the
+// middle ground: parse actual query parameters explicitly while keeping the
+// preview-only gate lightweight.
+function decodeQueryValue(value) {
+	try {
+		return decodeURIComponent(value.split("+").join(" "));
+	} catch (error) {
+		return value;
+	}
+}
+
+function getQueryParameterValue(name) {
+	const queryString = window.location.search.charAt(0) === "?"
+		? window.location.search.slice(1)
+		: window.location.search;
+
+	if (!queryString) {
+		return null;
+	}
+
+	const parameters = queryString.split("&");
+
+	for (let index = 0; index < parameters.length; index += 1) {
+		const parameter = parameters[index];
+		const separatorIndex = parameter.indexOf("=");
+		const parameterName = separatorIndex === -1 ? parameter : parameter.slice(0, separatorIndex);
+		const parameterValue = separatorIndex === -1 ? "" : parameter.slice(separatorIndex + 1);
+
+		if (decodeQueryValue(parameterName) === name) {
+			return decodeQueryValue(parameterValue);
+		}
+	}
+
+	return null;
+}
+
+const isBootstrap5Preview = getQueryParameterValue("bs5") === "1";
+
+if (isBootstrap5Preview) {
+	document.documentElement.classList.add("s-lg-bs5-preview");
+}
+
+function syncBootstrap5TabAttributes() {
+	document.querySelectorAll('[data-toggle="tab"]').forEach(function(tab) {
+		if (!tab.hasAttribute("data-bs-toggle")) {
+			tab.setAttribute("data-bs-toggle", "tab");
+		}
+	});
+}
+
 // This is inherited jQuery, it needs to be reviewed and possibly eliminated
 $(document).ready(function() {
+	if (isBootstrap5Preview) {
+		document.body.classList.add("s-lg-bs5-preview");
+		syncBootstrap5TabAttributes();
+	}
+
 	//Changing By Owner to By Author
 	// $('#s-lg-index-owner-btn').find('a').html("BY AUTHOR");
 	//Changing By Group to By Campus Location

--- a/scss/_bootstrap5.scss
+++ b/scss/_bootstrap5.scss
@@ -1,0 +1,353 @@
+@use 'colors' as *;
+@use 'variables' as *;
+
+@mixin nyu-link {
+  border-bottom: solid 1px rgba($text_blue, 0.3);
+  color: $text_blue;
+  text-decoration: none;
+}
+
+@mixin nyu-link-hover {
+  border-bottom: solid 1px $text_blue;
+  color: $text_blue;
+  text-decoration: none;
+}
+
+@mixin styles {
+  html.s-lg-bs5-preview {
+    --bs-link-color: #{$text_blue};
+    --bs-link-color-rgb: 1, 112, 178;
+    --bs-link-hover-color: #{$text_blue};
+    --bs-link-hover-color-rgb: 1, 112, 178;
+    --bs-primary: #{$nyu_purple};
+    --bs-primary-rgb: 87, 6, 140;
+  }
+
+  html.s-lg-bs5-preview #s-lib-bc .breadcrumb {
+    align-items: center;
+    display: flex;
+    font-size: $font_size_base;
+    font-weight: $weight_normal;
+    line-height: 1.42857143;
+  }
+
+  html.s-lg-bs5-preview #s-lib-bc .breadcrumb-item,
+  html.s-lg-bs5-preview #s-lib-bc .breadcrumb-item a {
+    align-items: center;
+    display: flex;
+    font-size: $font_size_base;
+    font-weight: $weight_normal;
+    line-height: 1.42857143;
+  }
+
+  html.s-lg-bs5-preview #s-lib-bc .breadcrumb-item.active {
+    align-items: center;
+    color: $text_black;
+    display: flex;
+    font-size: $font_size_base;
+    font-weight: $weight_normal;
+  }
+
+  html.s-lg-bs5-preview #s-lib-bc .breadcrumb-item + .breadcrumb-item::before {
+    line-height: inherit;
+  }
+
+  html.s-lg-bs5-preview #s-lib-bc #s-lib-bc-page.breadcrumb-item.active {
+    align-items: center;
+    color: $text_black !important;
+    display: flex;
+    font-size: $font_size_base !important;
+    font-weight: $weight_normal !important;
+    line-height: 1.42857143;
+  }
+
+  html.s-lg-bs5-preview #s-lib-bc a {
+    @include nyu-link;
+  }
+
+  html.s-lg-bs5-preview #s-lib-bc a:hover {
+    @include nyu-link-hover;
+  }
+
+  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li#s-lg-hp-nav-bottom form[role='search'] {
+    justify-content: flex-start !important;
+    width: 100%;
+  }
+
+  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li#s-lg-hp-nav-bottom .form-group,
+  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li#s-lg-hp-nav-bottom .s-lg-public-search-field,
+  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li#s-lg-hp-nav-bottom .input-group {
+    width: 100%;
+  }
+
+  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li#s-lg-hp-nav-bottom .form-group {
+    flex: 1 1 auto;
+  }
+
+  html.s-lg-bs5-preview input[type='text'].form-control:focus,
+  html.s-lg-bs5-preview input[type='text'].form-control:focus-visible,
+  html.s-lg-bs5-preview input[type='text'].bobcat_embed_searchbox_textfield:focus,
+  html.s-lg-bs5-preview input[type='text'].bobcat_embed_searchbox_textfield:focus-visible,
+  html.s-lg-bs5-preview input[type='search'].form-control:focus,
+  html.s-lg-bs5-preview input[type='search'].form-control:focus-visible,
+  html.s-lg-bs5-preview select.bobcat_embed_select_value:focus,
+  html.s-lg-bs5-preview select.bobcat_embed_select_value:focus-visible {
+    border-color: transparent !important;
+    -webkit-box-shadow: inset 0 0 0 2px $border_focus !important;
+    box-shadow: inset 0 0 0 2px $border_focus !important;
+    outline: 0 !important;
+  }
+
+  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li {
+    background-color: transparent;
+    border: 1px solid $border_solid_gray;
+    border-bottom: none;
+    border-radius: 3px 3px 0 0;
+    color: $text_dark_gray;
+    margin-right: 5px;
+    padding: 15px;
+  }
+
+  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li button,
+  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li button.btn {
+    background-color: transparent !important;
+    border-color: transparent !important;
+    box-shadow: none;
+    color: $text_dark_gray;
+    margin: 0;
+    padding: 0;
+    text-decoration: none;
+  }
+
+  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li button:hover,
+  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li button:focus,
+  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li button.btn:hover,
+  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li button.btn:focus {
+    background-color: transparent !important;
+    border-color: transparent !important;
+    color: $text_dark_gray;
+    text-decoration: underline;
+  }
+
+  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active {
+    background: $background_black;
+    pointer-events: none;
+  }
+
+  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active button,
+  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active button.btn,
+  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active button:hover,
+  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active button:focus,
+  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active button.btn:hover,
+  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active button.btn:focus {
+    background-color: transparent !important;
+    border-color: transparent !important;
+    color: #fff;
+    text-decoration: none;
+  }
+
+  html.s-lg-bs5-preview #s-lg-hp-nav.mb-3,
+  html.s-lg-bs5-preview #s-lg-hp-nav .nav-pills.mb-3 {
+    margin-bottom: 0 !important;
+  }
+
+  html.s-lg-bs5-preview #s-lg-hp-nav .nav-pills.mb-3 {
+    border-bottom: 1px solid $border_solid_gray;
+  }
+
+  html.s-lg-bs5-preview #s-lg-sb-count.badge,
+  html.s-lg-bs5-preview #s-lg-sb-count.bg-secondary {
+    background-color: $text_black !important;
+    color: #fff;
+  }
+
+  html.s-lg-bs5-preview #s-lg-index-list-subjects a {
+    @include nyu-link;
+  }
+
+  html.s-lg-bs5-preview #s-lg-index-list-subjects a:hover,
+  html.s-lg-bs5-preview #s-lg-index-list-subjects a:focus {
+    @include nyu-link-hover;
+  }
+
+  html.s-lg-bs5-preview #s-lg-index-list-subjects .accordion-button {
+    background-color: #f5f5f5;
+    border-bottom: 0;
+    color: $text_black;
+    cursor: default;
+    font-size: $font_size_base;
+    font-weight: $weight_normal;
+    text-decoration: none;
+  }
+
+  html.s-lg-bs5-preview #s-lg-index-list-subjects .accordion-button:hover,
+  html.s-lg-bs5-preview #s-lg-index-list-subjects .accordion-button:focus {
+    background-color: #f5f5f5;
+    border-bottom: 0;
+    color: $text_black;
+    text-decoration: none;
+  }
+
+  html.s-lg-bs5-preview #s-lg-index-list-subjects .accordion-button:focus,
+  html.s-lg-bs5-preview #s-lg-index-list-subjects .accordion-button:focus-visible {
+    -webkit-box-shadow: inset 0 0 0 2px $border_focus !important;
+    box-shadow: inset 0 0 0 2px $border_focus !important;
+    outline: 0 !important;
+  }
+
+  html.s-lg-bs5-preview #s-lg-index-list-subjects .accordion-button .bold {
+    @include nyu-link;
+    cursor: pointer;
+    display: inline-block;
+    order: 1;
+  }
+
+  html.s-lg-bs5-preview #s-lg-index-list-subjects .accordion-button .bold:hover {
+    @include nyu-link-hover;
+  }
+
+  html.s-lg-bs5-preview #s-lg-index-list-subjects .accordion-button .badge.pull-right {
+    border-radius: 10px;
+    border-bottom: solid 1px transparent;
+    cursor: pointer;
+    display: inline-block;
+    float: right;
+    font-size: 12px;
+    font-weight: $weight_bold;
+    line-height: 1;
+    margin-left: auto;
+    min-width: 10px;
+    order: 2;
+    padding: 3px 7px;
+    text-align: center;
+    vertical-align: middle;
+    white-space: nowrap;
+  }
+
+  html.s-lg-bs5-preview #s-lg-index-list-subjects .accordion-button .badge.pull-right:hover {
+    border-bottom: solid 1px $text_blue;
+  }
+
+  html.s-lg-bs5-preview #s-lg-index-list-subjects .accordion-button::after {
+    margin-left: 0.5rem;
+    order: 3;
+  }
+
+  html.s-lg-bs5-preview #s-lg-index-list .badge,
+  html.s-lg-bs5-preview #s-lg-index-list-subjects .badge {
+    background-color: $text_black !important;
+    color: #fff;
+  }
+
+  html.s-lg-bs5-preview #s-lg-sb-cols .nav-tabs {
+    border-bottom: 1px solid #ddd;
+    display: flex;
+    flex-wrap: wrap;
+    list-style: none;
+    padding-left: 0;
+  }
+
+  html.s-lg-bs5-preview #s-lg-sb-cols .nav-tabs > li {
+    margin-bottom: -1px;
+  }
+
+  html.s-lg-bs5-preview #s-lg-sb-cols .nav-tabs > li > a {
+    border: 1px solid transparent;
+    border-bottom: solid 1px rgba($text_blue, 0.3);
+    border-radius: 4px 4px 0 0;
+    color: $text_blue;
+    display: block;
+    line-height: 1.42857143;
+    margin-right: 2px;
+    padding: 10px 15px;
+    text-decoration: none;
+  }
+
+  html.s-lg-bs5-preview #s-lg-sb-cols .nav-tabs > li > a:hover,
+  html.s-lg-bs5-preview #s-lg-sb-cols .nav-tabs > li > a:focus {
+    background-color: #eee;
+    border-color: #eee #eee #ddd;
+    border-bottom: solid 1px $text_blue;
+    color: $text_blue;
+    text-decoration: none;
+  }
+
+  html.s-lg-bs5-preview #s-lg-sb-cols .nav-tabs > li.active > a,
+  html.s-lg-bs5-preview #s-lg-sb-cols .nav-tabs > li.active > a:hover,
+  html.s-lg-bs5-preview #s-lg-sb-cols .nav-tabs > li.active > a:focus {
+    background-color: #fff;
+    border: 1px solid #ddd;
+    border-bottom-color: transparent;
+    color: $text_blue;
+    cursor: default;
+    text-decoration: none;
+  }
+
+  html.s-lg-bs5-preview #s-lg-sb-cols .tab-content > .tab-pane {
+    display: none;
+  }
+
+  html.s-lg-bs5-preview #s-lg-sb-cols .tab-content > .active {
+    display: block;
+  }
+
+  html.s-lg-bs5-preview #s-lib-public-main .pagination .page-link {
+    background-color: #fff;
+    border: 1px solid #ddd;
+    border-bottom: solid 1px rgba($text_blue, 0.3);
+    color: $text_blue;
+    text-decoration: none;
+  }
+
+  html.s-lg-bs5-preview #s-lib-public-main .pagination .page-link:hover,
+  html.s-lg-bs5-preview #s-lib-public-main .pagination .page-link:focus {
+    background-color: #eee;
+    border-color: #ddd;
+    border-bottom: solid 1px $text_blue;
+    color: $text_blue;
+    text-decoration: none;
+  }
+
+  html.s-lg-bs5-preview #s-lib-public-main .pagination .page-item.active .page-link {
+    background-color: $text_blue;
+    border-color: $text_blue;
+    color: #fff;
+  }
+
+  html.s-lg-bs5-preview #s-lib-public-main .pagination .page-item.disabled .page-link {
+    background-color: #fff;
+    border-color: #ddd;
+    color: $text_dark_gray;
+  }
+
+  html.s-lg-bs5-preview #s-lg-srch-content .fw-bold,
+  html.s-lg-bs5-preview #s-lg-srch-content .fw-bold .dropdown-toggle,
+  html.s-lg-bs5-preview #s-lg-srch-content .dropdown-menu {
+    font-size: $font_size_base;
+  }
+
+  html.s-lg-bs5-preview #s-lib-public-main #s-lg-srch-content .dropdown-menu .dropdown-item {
+    border-bottom: 0;
+    color: #333333;
+    font-size: 12px;
+    padding: 3px 20px;
+    text-decoration: none;
+  }
+
+  html.s-lg-bs5-preview #s-lib-public-main #s-lg-srch-content .dropdown-menu li {
+    border-bottom: 1px solid rgba($text_blue, 0.3);
+  }
+
+  html.s-lg-bs5-preview #s-lib-public-main #s-lg-srch-content .dropdown-menu li:hover,
+  html.s-lg-bs5-preview #s-lib-public-main #s-lg-srch-content .dropdown-menu li:focus-within {
+    border-bottom-color: $text_blue;
+  }
+
+  html.s-lg-bs5-preview #s-lib-public-main #s-lg-srch-content .dropdown-menu .dropdown-item:hover,
+  html.s-lg-bs5-preview #s-lib-public-main #s-lg-srch-content .dropdown-menu .dropdown-item:focus {
+    background-color: #f5f5f5;
+    border-bottom: 0;
+    color: #333333;
+    text-decoration: none;
+  }
+}

--- a/scss/_bootstrap5.scss
+++ b/scss/_bootstrap5.scss
@@ -14,7 +14,7 @@
 }
 
 @mixin styles {
-  html.s-lg-bs5-preview {
+  html.nyu-libguides-bs5-preview {
     --bs-link-color: #{$text_blue};
     --bs-link-color-rgb: 1, 112, 178;
     --bs-link-hover-color: #{$text_blue};
@@ -23,7 +23,7 @@
     --bs-primary-rgb: 87, 6, 140;
   }
 
-  html.s-lg-bs5-preview #s-lib-bc .breadcrumb {
+  html.nyu-libguides-bs5-preview #s-lib-bc .breadcrumb {
     align-items: center;
     display: flex;
     font-size: $font_size_base;
@@ -31,8 +31,8 @@
     line-height: 1.42857143;
   }
 
-  html.s-lg-bs5-preview #s-lib-bc .breadcrumb-item,
-  html.s-lg-bs5-preview #s-lib-bc .breadcrumb-item a {
+  html.nyu-libguides-bs5-preview #s-lib-bc .breadcrumb-item,
+  html.nyu-libguides-bs5-preview #s-lib-bc .breadcrumb-item a {
     align-items: center;
     display: flex;
     font-size: $font_size_base;
@@ -40,7 +40,7 @@
     line-height: 1.42857143;
   }
 
-  html.s-lg-bs5-preview #s-lib-bc .breadcrumb-item.active {
+  html.nyu-libguides-bs5-preview #s-lib-bc .breadcrumb-item.active {
     align-items: center;
     color: $text_black;
     display: flex;
@@ -48,11 +48,11 @@
     font-weight: $weight_normal;
   }
 
-  html.s-lg-bs5-preview #s-lib-bc .breadcrumb-item + .breadcrumb-item::before {
+  html.nyu-libguides-bs5-preview #s-lib-bc .breadcrumb-item + .breadcrumb-item::before {
     line-height: inherit;
   }
 
-  html.s-lg-bs5-preview #s-lib-bc #s-lib-bc-page.breadcrumb-item.active {
+  html.nyu-libguides-bs5-preview #s-lib-bc #s-lib-bc-page.breadcrumb-item.active {
     align-items: center;
     color: $text_black !important;
     display: flex;
@@ -61,44 +61,44 @@
     line-height: 1.42857143;
   }
 
-  html.s-lg-bs5-preview #s-lib-bc a {
+  html.nyu-libguides-bs5-preview #s-lib-bc a {
     @include nyu-link;
   }
 
-  html.s-lg-bs5-preview #s-lib-bc a:hover {
+  html.nyu-libguides-bs5-preview #s-lib-bc a:hover {
     @include nyu-link-hover;
   }
 
-  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li#s-lg-hp-nav-bottom form[role='search'] {
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav > ul > li#s-lg-hp-nav-bottom form[role='search'] {
     justify-content: flex-start !important;
     width: 100%;
   }
 
-  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li#s-lg-hp-nav-bottom .form-group,
-  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li#s-lg-hp-nav-bottom .s-lg-public-search-field,
-  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li#s-lg-hp-nav-bottom .input-group {
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav > ul > li#s-lg-hp-nav-bottom .form-group,
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav > ul > li#s-lg-hp-nav-bottom .s-lg-public-search-field,
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav > ul > li#s-lg-hp-nav-bottom .input-group {
     width: 100%;
   }
 
-  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li#s-lg-hp-nav-bottom .form-group {
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav > ul > li#s-lg-hp-nav-bottom .form-group {
     flex: 1 1 auto;
   }
 
-  html.s-lg-bs5-preview input[type='text'].form-control:focus,
-  html.s-lg-bs5-preview input[type='text'].form-control:focus-visible,
-  html.s-lg-bs5-preview input[type='text'].bobcat_embed_searchbox_textfield:focus,
-  html.s-lg-bs5-preview input[type='text'].bobcat_embed_searchbox_textfield:focus-visible,
-  html.s-lg-bs5-preview input[type='search'].form-control:focus,
-  html.s-lg-bs5-preview input[type='search'].form-control:focus-visible,
-  html.s-lg-bs5-preview select.bobcat_embed_select_value:focus,
-  html.s-lg-bs5-preview select.bobcat_embed_select_value:focus-visible {
+  html.nyu-libguides-bs5-preview input[type='text'].form-control:focus,
+  html.nyu-libguides-bs5-preview input[type='text'].form-control:focus-visible,
+  html.nyu-libguides-bs5-preview input[type='text'].bobcat_embed_searchbox_textfield:focus,
+  html.nyu-libguides-bs5-preview input[type='text'].bobcat_embed_searchbox_textfield:focus-visible,
+  html.nyu-libguides-bs5-preview input[type='search'].form-control:focus,
+  html.nyu-libguides-bs5-preview input[type='search'].form-control:focus-visible,
+  html.nyu-libguides-bs5-preview select.bobcat_embed_select_value:focus,
+  html.nyu-libguides-bs5-preview select.bobcat_embed_select_value:focus-visible {
     border-color: transparent !important;
     -webkit-box-shadow: inset 0 0 0 2px $border_focus !important;
     box-shadow: inset 0 0 0 2px $border_focus !important;
     outline: 0 !important;
   }
 
-  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li {
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li {
     background-color: transparent;
     border: 1px solid $border_solid_gray;
     border-bottom: none;
@@ -108,8 +108,8 @@
     padding: 15px;
   }
 
-  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li button,
-  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li button.btn {
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li button,
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li button.btn {
     background-color: transparent !important;
     border-color: transparent !important;
     box-shadow: none;
@@ -119,58 +119,58 @@
     text-decoration: none;
   }
 
-  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li button:hover,
-  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li button:focus,
-  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li button.btn:hover,
-  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li button.btn:focus {
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li button:hover,
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li button:focus,
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li button.btn:hover,
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li button.btn:focus {
     background-color: transparent !important;
     border-color: transparent !important;
     color: $text_dark_gray;
     text-decoration: underline;
   }
 
-  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active {
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active {
     background: $background_black;
     pointer-events: none;
   }
 
-  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active button,
-  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active button.btn,
-  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active button:hover,
-  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active button:focus,
-  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active button.btn:hover,
-  html.s-lg-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active button.btn:focus {
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active button,
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active button.btn,
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active button:hover,
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active button:focus,
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active button.btn:hover,
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav > ul > li .nav-pills li.active button.btn:focus {
     background-color: transparent !important;
     border-color: transparent !important;
     color: #fff;
     text-decoration: none;
   }
 
-  html.s-lg-bs5-preview #s-lg-hp-nav.mb-3,
-  html.s-lg-bs5-preview #s-lg-hp-nav .nav-pills.mb-3 {
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav.mb-3,
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav .nav-pills.mb-3 {
     margin-bottom: 0 !important;
   }
 
-  html.s-lg-bs5-preview #s-lg-hp-nav .nav-pills.mb-3 {
+  html.nyu-libguides-bs5-preview #s-lg-hp-nav .nav-pills.mb-3 {
     border-bottom: 1px solid $border_solid_gray;
   }
 
-  html.s-lg-bs5-preview #s-lg-sb-count.badge,
-  html.s-lg-bs5-preview #s-lg-sb-count.bg-secondary {
+  html.nyu-libguides-bs5-preview #s-lg-sb-count.badge,
+  html.nyu-libguides-bs5-preview #s-lg-sb-count.bg-secondary {
     background-color: $text_black !important;
     color: #fff;
   }
 
-  html.s-lg-bs5-preview #s-lg-index-list-subjects a {
+  html.nyu-libguides-bs5-preview #s-lg-index-list-subjects a {
     @include nyu-link;
   }
 
-  html.s-lg-bs5-preview #s-lg-index-list-subjects a:hover,
-  html.s-lg-bs5-preview #s-lg-index-list-subjects a:focus {
+  html.nyu-libguides-bs5-preview #s-lg-index-list-subjects a:hover,
+  html.nyu-libguides-bs5-preview #s-lg-index-list-subjects a:focus {
     @include nyu-link-hover;
   }
 
-  html.s-lg-bs5-preview #s-lg-index-list-subjects .accordion-button {
+  html.nyu-libguides-bs5-preview #s-lg-index-list-subjects .accordion-button {
     background-color: #f5f5f5;
     border-bottom: 0;
     color: $text_black;
@@ -180,33 +180,33 @@
     text-decoration: none;
   }
 
-  html.s-lg-bs5-preview #s-lg-index-list-subjects .accordion-button:hover,
-  html.s-lg-bs5-preview #s-lg-index-list-subjects .accordion-button:focus {
+  html.nyu-libguides-bs5-preview #s-lg-index-list-subjects .accordion-button:hover,
+  html.nyu-libguides-bs5-preview #s-lg-index-list-subjects .accordion-button:focus {
     background-color: #f5f5f5;
     border-bottom: 0;
     color: $text_black;
     text-decoration: none;
   }
 
-  html.s-lg-bs5-preview #s-lg-index-list-subjects .accordion-button:focus,
-  html.s-lg-bs5-preview #s-lg-index-list-subjects .accordion-button:focus-visible {
+  html.nyu-libguides-bs5-preview #s-lg-index-list-subjects .accordion-button:focus,
+  html.nyu-libguides-bs5-preview #s-lg-index-list-subjects .accordion-button:focus-visible {
     -webkit-box-shadow: inset 0 0 0 2px $border_focus !important;
     box-shadow: inset 0 0 0 2px $border_focus !important;
     outline: 0 !important;
   }
 
-  html.s-lg-bs5-preview #s-lg-index-list-subjects .accordion-button .bold {
+  html.nyu-libguides-bs5-preview #s-lg-index-list-subjects .accordion-button .bold {
     @include nyu-link;
     cursor: pointer;
     display: inline-block;
     order: 1;
   }
 
-  html.s-lg-bs5-preview #s-lg-index-list-subjects .accordion-button .bold:hover {
+  html.nyu-libguides-bs5-preview #s-lg-index-list-subjects .accordion-button .bold:hover {
     @include nyu-link-hover;
   }
 
-  html.s-lg-bs5-preview #s-lg-index-list-subjects .accordion-button .badge.pull-right {
+  html.nyu-libguides-bs5-preview #s-lg-index-list-subjects .accordion-button .badge.pull-right {
     border-radius: 10px;
     border-bottom: solid 1px transparent;
     cursor: pointer;
@@ -224,22 +224,22 @@
     white-space: nowrap;
   }
 
-  html.s-lg-bs5-preview #s-lg-index-list-subjects .accordion-button .badge.pull-right:hover {
+  html.nyu-libguides-bs5-preview #s-lg-index-list-subjects .accordion-button .badge.pull-right:hover {
     border-bottom: solid 1px $text_blue;
   }
 
-  html.s-lg-bs5-preview #s-lg-index-list-subjects .accordion-button::after {
+  html.nyu-libguides-bs5-preview #s-lg-index-list-subjects .accordion-button::after {
     margin-left: 0.5rem;
     order: 3;
   }
 
-  html.s-lg-bs5-preview #s-lg-index-list .badge,
-  html.s-lg-bs5-preview #s-lg-index-list-subjects .badge {
+  html.nyu-libguides-bs5-preview #s-lg-index-list .badge,
+  html.nyu-libguides-bs5-preview #s-lg-index-list-subjects .badge {
     background-color: $text_black !important;
     color: #fff;
   }
 
-  html.s-lg-bs5-preview #s-lg-sb-cols .nav-tabs {
+  html.nyu-libguides-bs5-preview #s-lg-sb-cols .nav-tabs {
     border-bottom: 1px solid #ddd;
     display: flex;
     flex-wrap: wrap;
@@ -247,11 +247,11 @@
     padding-left: 0;
   }
 
-  html.s-lg-bs5-preview #s-lg-sb-cols .nav-tabs > li {
+  html.nyu-libguides-bs5-preview #s-lg-sb-cols .nav-tabs > li {
     margin-bottom: -1px;
   }
 
-  html.s-lg-bs5-preview #s-lg-sb-cols .nav-tabs > li > a {
+  html.nyu-libguides-bs5-preview #s-lg-sb-cols .nav-tabs > li > a {
     border: 1px solid transparent;
     border-bottom: solid 1px rgba($text_blue, 0.3);
     border-radius: 4px 4px 0 0;
@@ -263,8 +263,8 @@
     text-decoration: none;
   }
 
-  html.s-lg-bs5-preview #s-lg-sb-cols .nav-tabs > li > a:hover,
-  html.s-lg-bs5-preview #s-lg-sb-cols .nav-tabs > li > a:focus {
+  html.nyu-libguides-bs5-preview #s-lg-sb-cols .nav-tabs > li > a:hover,
+  html.nyu-libguides-bs5-preview #s-lg-sb-cols .nav-tabs > li > a:focus {
     background-color: #eee;
     border-color: #eee #eee #ddd;
     border-bottom: solid 1px $text_blue;
@@ -272,9 +272,9 @@
     text-decoration: none;
   }
 
-  html.s-lg-bs5-preview #s-lg-sb-cols .nav-tabs > li.active > a,
-  html.s-lg-bs5-preview #s-lg-sb-cols .nav-tabs > li.active > a:hover,
-  html.s-lg-bs5-preview #s-lg-sb-cols .nav-tabs > li.active > a:focus {
+  html.nyu-libguides-bs5-preview #s-lg-sb-cols .nav-tabs > li.active > a,
+  html.nyu-libguides-bs5-preview #s-lg-sb-cols .nav-tabs > li.active > a:hover,
+  html.nyu-libguides-bs5-preview #s-lg-sb-cols .nav-tabs > li.active > a:focus {
     background-color: #fff;
     border: 1px solid #ddd;
     border-bottom-color: transparent;
@@ -283,15 +283,15 @@
     text-decoration: none;
   }
 
-  html.s-lg-bs5-preview #s-lg-sb-cols .tab-content > .tab-pane {
+  html.nyu-libguides-bs5-preview #s-lg-sb-cols .tab-content > .tab-pane {
     display: none;
   }
 
-  html.s-lg-bs5-preview #s-lg-sb-cols .tab-content > .active {
+  html.nyu-libguides-bs5-preview #s-lg-sb-cols .tab-content > .active {
     display: block;
   }
 
-  html.s-lg-bs5-preview #s-lib-public-main .pagination .page-link {
+  html.nyu-libguides-bs5-preview #s-lib-public-main .pagination .page-link {
     background-color: #fff;
     border: 1px solid #ddd;
     border-bottom: solid 1px rgba($text_blue, 0.3);
@@ -299,8 +299,8 @@
     text-decoration: none;
   }
 
-  html.s-lg-bs5-preview #s-lib-public-main .pagination .page-link:hover,
-  html.s-lg-bs5-preview #s-lib-public-main .pagination .page-link:focus {
+  html.nyu-libguides-bs5-preview #s-lib-public-main .pagination .page-link:hover,
+  html.nyu-libguides-bs5-preview #s-lib-public-main .pagination .page-link:focus {
     background-color: #eee;
     border-color: #ddd;
     border-bottom: solid 1px $text_blue;
@@ -308,25 +308,25 @@
     text-decoration: none;
   }
 
-  html.s-lg-bs5-preview #s-lib-public-main .pagination .page-item.active .page-link {
+  html.nyu-libguides-bs5-preview #s-lib-public-main .pagination .page-item.active .page-link {
     background-color: $text_blue;
     border-color: $text_blue;
     color: #fff;
   }
 
-  html.s-lg-bs5-preview #s-lib-public-main .pagination .page-item.disabled .page-link {
+  html.nyu-libguides-bs5-preview #s-lib-public-main .pagination .page-item.disabled .page-link {
     background-color: #fff;
     border-color: #ddd;
     color: $text_dark_gray;
   }
 
-  html.s-lg-bs5-preview #s-lg-srch-content .fw-bold,
-  html.s-lg-bs5-preview #s-lg-srch-content .fw-bold .dropdown-toggle,
-  html.s-lg-bs5-preview #s-lg-srch-content .dropdown-menu {
+  html.nyu-libguides-bs5-preview #s-lg-srch-content .fw-bold,
+  html.nyu-libguides-bs5-preview #s-lg-srch-content .fw-bold .dropdown-toggle,
+  html.nyu-libguides-bs5-preview #s-lg-srch-content .dropdown-menu {
     font-size: $font_size_base;
   }
 
-  html.s-lg-bs5-preview #s-lib-public-main #s-lg-srch-content .dropdown-menu .dropdown-item {
+  html.nyu-libguides-bs5-preview #s-lib-public-main #s-lg-srch-content .dropdown-menu .dropdown-item {
     border-bottom: 0;
     color: #333333;
     font-size: 12px;
@@ -334,17 +334,17 @@
     text-decoration: none;
   }
 
-  html.s-lg-bs5-preview #s-lib-public-main #s-lg-srch-content .dropdown-menu li {
+  html.nyu-libguides-bs5-preview #s-lib-public-main #s-lg-srch-content .dropdown-menu li {
     border-bottom: 1px solid rgba($text_blue, 0.3);
   }
 
-  html.s-lg-bs5-preview #s-lib-public-main #s-lg-srch-content .dropdown-menu li:hover,
-  html.s-lg-bs5-preview #s-lib-public-main #s-lg-srch-content .dropdown-menu li:focus-within {
+  html.nyu-libguides-bs5-preview #s-lib-public-main #s-lg-srch-content .dropdown-menu li:hover,
+  html.nyu-libguides-bs5-preview #s-lib-public-main #s-lg-srch-content .dropdown-menu li:focus-within {
     border-bottom-color: $text_blue;
   }
 
-  html.s-lg-bs5-preview #s-lib-public-main #s-lg-srch-content .dropdown-menu .dropdown-item:hover,
-  html.s-lg-bs5-preview #s-lib-public-main #s-lg-srch-content .dropdown-menu .dropdown-item:focus {
+  html.nyu-libguides-bs5-preview #s-lib-public-main #s-lg-srch-content .dropdown-menu .dropdown-item:hover,
+  html.nyu-libguides-bs5-preview #s-lib-public-main #s-lg-srch-content .dropdown-menu .dropdown-item:focus {
     background-color: #f5f5f5;
     border-bottom: 0;
     color: #333333;

--- a/scss/index.scss
+++ b/scss/index.scss
@@ -1,6 +1,7 @@
 @use 'a11y';
 @use 'arch';
 @use 'blog';
+@use 'bootstrap5' as bootstrap5;
 @use 'breadcrumbs' as *;
 @use 'buttons';
 @use 'colors' as *;
@@ -200,4 +201,4 @@ input[type='text'].s-lg-form-control {
   border-bottom: solid 1px $text_blue;
 }
 
-
+@include bootstrap5.styles;

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/nyulibraries/nginx:1.17.3-0-pre
+FROM nginxinc/nginx-unprivileged:1.27.5-alpine
 
 # Custom config files
 COPY --chown=nginx:nginx nginx/default.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
Re: https://nyu-lib.monday.com/boards/765008773/pulses/11746487779

## Summary
- Add an exact bs5=1 preview gate that scopes Bootstrap 5-only behavior to preview URLs.
- Add scoped Bootstrap 5 LibGuides style overrides for breadcrumbs, homepage subject lists, search controls, search pagination/dropdowns, subject tabs, badges, and group tabs.
- Update the local test nginx image so Docker can build with a supported image manifest.