### PR TITLE
Add transparent background for active dropdown item in tab container

### DIFF
--- a/scss/_bootstrap5.scss
+++ b/scss/_bootstrap5.scss
@@ -155,6 +155,10 @@
     border-bottom: 1px solid $border_solid_gray;
   }
 
+  html.nyu-libguides-bs5-preview #s-lg-tabs-container .dropdown-item.active {
+    background-color: transparent;
+  }
+
   html.nyu-libguides-bs5-preview #s-lg-sb-count.badge,
   html.nyu-libguides-bs5-preview #s-lg-sb-count.bg-secondary {
     background-color: $text_black !important;


### PR DESCRIPTION
Re: https://nyu-lib.monday.com/boards/765008773/pulses/12362894833

Replaces #75, which was closed when its mis-spelled head branch (`fix/subpage-side-nav-stying`) was renamed to `fix/subpage-side-nav-styling`.